### PR TITLE
Add Laravel 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "require": {
         "php": "^7.3|^8.0",
-        "illuminate/support": "^8"
+        "illuminate/support": "^8|^9"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
Allow the package to be used with Laravel 9. Haven't really tested it yet, but so far haven't had errors.