### PR TITLE
allow for individual connections to be passed to afas connection

### DIFF
--- a/src/AfasConnection.php
+++ b/src/AfasConnection.php
@@ -21,13 +21,18 @@ class AfasConnection
      * @param bool $jsonFilter
      * @return AfasGetConnector
      */
-    public function getConnector(string $name, bool $jsonFilter = false): AfasGetConnector
+    public function getConnector(string $name, bool $jsonFilter = false, string $token = null, string $environment = null): AfasGetConnector
     {
         if (!array_key_exists($name, $this->config['getConnectors'])) {
             throw new \InvalidArgumentException("GetConnector $name is not configured for this connection.");
         }
 
         $config = $this->config['getConnectors'][$name];
+
+        if($token && $environment) {
+            $config['token'] = $token;
+            $config['environment'] = $environment;
+        }
 
         return new AfasGetConnector($this, $config, $jsonFilter);
     }
@@ -37,7 +42,7 @@ class AfasConnection
      * @param string $name
      * @return AfasUpdateConnector
      */
-    public function updateConnector(string $name): AfasUpdateConnector
+    public function updateConnector(string $name, string $token = null, string $environment = null): AfasUpdateConnector
     {
         if (!array_key_exists($name, $this->config['updateConnectors'])) {
             throw new \InvalidArgumentException("UpdateConnector $name is not configured for this connection.");
@@ -45,6 +50,11 @@ class AfasConnection
 
         $config = $this->config['updateConnectors'][$name];
 
+        if($token && $environment) {
+            $config['token'] = $token;
+            $config['environment'] = $environment;
+        }
+        
         return new AfasUpdateConnector($this, $config);
     }
 

--- a/src/AfasConnectionManager.php
+++ b/src/AfasConnectionManager.php
@@ -19,7 +19,7 @@ class AfasConnectionManager
      * @param string $name
      * @return AfasConnection
      */
-    public function connection(string $name = 'default'): AfasConnection
+    public function connection(string $name = 'default', string $token, string $environment): AfasConnection
     {
         if (!array_key_exists($name, $this->config['connections'])) {
             throw new \InvalidArgumentException("Connection $name is not configured.");
@@ -27,6 +27,11 @@ class AfasConnectionManager
 
         $config = $this->config['connections'][$name];
 
+        if($token && $environment) {
+            $config['token'] = $token;
+            $config['environment'] = $environment;
+        }
+        
         return new AfasConnection($config);
     }
 
@@ -36,9 +41,9 @@ class AfasConnectionManager
      * @param string $connection
      * @return AfasGetConnector
      */
-    public function getConnector(string $name, bool $jsonFilter = false , string $connection = 'default'): AfasGetConnector
+    public function getConnector(string $name, bool $jsonFilter = false , string $connection = 'default', string $token = null, string $environment = null): AfasGetConnector
     {
-        return $this->connection($connection)->getConnector($name, $jsonFilter);
+        return $this->connection($connection, $token, $environment)->getConnector($name, $jsonFilter);
     }
 
     /**


### PR DESCRIPTION
This PR allows for adding multiple (dynamic connections) that aren't stored in the config file. We use this as we have multiple users, using the same connectors across different administrations.